### PR TITLE
Update for Dark Fog version

### DIFF
--- a/Bottleneck.csproj
+++ b/Bottleneck.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Bottleneck</AssemblyName>
     <Description>Production bottleneck finder</Description>
-    <Version>1.0.15</Version>
+    <Version>1.0.16</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>9.0</LangVersion>
   </PropertyGroup>
@@ -18,7 +18,6 @@
     <PackageReference Include="BepInEx.Core" Version="5.*" />
     <PackageReference Include="BepInEx.PluginInfoProps" Version="1.*" />
     <PackageReference Include="DysonSphereProgram.GameLibs" Version="*-*" />
-    <PackageReference Include="DysonSphereProgram.Modding.CommonAPI" Version="*-*" />
     <PackageReference Include="DysonSphereProgram.Modding.NebulaMultiplayerModApi" Version="1.2.0" />
     <PackageReference Include="UnityEngine.Modules" Version="2018.4.12" IncludeAssets="compile" />
   </ItemGroup>

--- a/BottleneckPlugin.cs
+++ b/BottleneckPlugin.cs
@@ -6,8 +6,7 @@ using Bottleneck.Nebula;
 using Bottleneck.Stats;
 using Bottleneck.UI;
 using Bottleneck.Util;
-using CommonAPI;
-using CommonAPI.Systems;
+
 using HarmonyLib;
 using UnityEngine;
 using UnityEngine.UI;
@@ -16,8 +15,7 @@ namespace Bottleneck
 {
     [BepInPlugin(PluginInfo.PLUGIN_GUID, PluginInfo.PLUGIN_NAME, PluginInfo.PLUGIN_VERSION)]
     [BepInDependency("dsp.nebula-multiplayer-api", BepInDependency.DependencyFlags.SoftDependency)]
-    [BepInDependency(CommonAPIPlugin.GUID)]
-    [CommonAPISubmoduleDependency(nameof(ProtoRegistry))]
+
     public class BottleneckPlugin : BaseUnityPlugin
     {
         public static BottleneckPlugin Instance => _instance;
@@ -53,12 +51,9 @@ namespace Bottleneck
         {
             Log.logger = Logger;
             _instance = this;
-            using (ProtoRegistry.StartModLoad(PluginInfo.PLUGIN_GUID))
-            {
-                Strings.Init();
-            }
             _harmony = new Harmony(PluginInfo.PLUGIN_GUID);
             _harmony.PatchAll(typeof(BottleneckPlugin));
+            Logger.LogDebug(Config);
             PluginConfig.InitConfig(Config);
             Log.Info($"Plugin {PluginInfo.PLUGIN_GUID} {PluginInfo.PLUGIN_VERSION} is loaded!");
 
@@ -270,9 +265,9 @@ namespace Bottleneck
             if (!__instance.isDysonTab && __instance.gameData.localPlanet != null && instanceAstroBox.Items.Count > 2)
             {
                 int starId = __instance.gameData.localStar.id;
-                if (instanceAstroBox.Items[2] != "localSystemLabel".Translate(PluginConfig.GetLanguage()))
+                if (instanceAstroBox.Items[2] != "localSystemLabel".Translate())
                 {
-                    instanceAstroBox.Items.Insert(2, "localSystemLabel".Translate(PluginConfig.GetLanguage()));
+                    instanceAstroBox.Items.Insert(2, "localSystemLabel".Translate());
                     instanceAstroBox.ItemsData.Insert(2, starId * 100);
                 }
             }
@@ -297,7 +292,7 @@ namespace Bottleneck
                     // hide star systems, unless we get a hit for one of stars in system
                     currentSystemId = astroId;
                     var starName = UIRoot.instance.uiGame.statWindow.gameData.galaxy.StarById(astroId / 100).displayName;
-                    currentSystemName = starName + "空格行星系".Translate(PluginConfig.GetLanguage());
+                    currentSystemName = starName + "空格行星系".Translate();
                 }
                 else
                 {
@@ -492,7 +487,7 @@ namespace Bottleneck
 
         public void GetPrecursorButtonTip(int productId, out string tipTitle, out string tipText)
         {
-            tipTitle = "prodDetailsLabel".Translate(PluginConfig.GetLanguage());
+            tipTitle = "prodDetailsLabel".Translate();
             tipText = "";
 
             if (NebulaCompat.IsClient)
@@ -503,13 +498,13 @@ namespace Bottleneck
             }
 
             if (ItemUtil.HasPrecursors(productId))
-                tipTitle += "clickPrecursorText".Translate(PluginConfig.GetLanguage());
+                tipTitle += "clickPrecursorText".Translate();
             if (_productionLocations.ContainsKey(productId))
             {
                 if (_enableMadeOn)
                 {
-                    var parensMessage = ItemUtil.HasPrecursors(productId) ? "controlClickLacking".Translate(PluginConfig.GetLanguage()) : "";
-                    var producedOnText = "producedOnLabel".Translate(PluginConfig.GetLanguage());
+                    var parensMessage = ItemUtil.HasPrecursors(productId) ? "controlClickLacking".Translate() : "";
+                    var producedOnText = "producedOnLabel".Translate();
                     tipText = $"{parensMessage}<b>{producedOnText}</b>\r\n" + _productionLocations[productId].GetProducerSummary();
                     if (_productionLocations[productId].PlanetCount() > PluginConfig.productionPlanetCount.Value)
                         tipTitle += $" (top {PluginConfig.productionPlanetCount.Value} / {_productionLocations[productId].PlanetCount()} planets)";
@@ -527,7 +522,7 @@ namespace Bottleneck
 
         public void GetSuccessorButtonTip(int productId, out string tipTitle, out string tipText)
         {
-            tipTitle = "conDetailsLabel".Translate(PluginConfig.GetLanguage());
+            tipTitle = "conDetailsLabel".Translate();
             tipText = "";
 
             if (NebulaCompat.IsClient)
@@ -538,10 +533,10 @@ namespace Bottleneck
             }
 
             if (ItemUtil.HasConsumers(productId))
-                tipTitle += "clickConsumingText".Translate(PluginConfig.GetLanguage());
+                tipTitle += "clickConsumingText".Translate();
             if (_productionLocations.ContainsKey(productId) && _enableMadeOn)
             { 
-                var consumedOnText = "consumedOnLabel".Translate(PluginConfig.GetLanguage());
+                var consumedOnText = "consumedOnLabel".Translate();
 
                 tipText = $"<b>{consumedOnText}</b>\r\n" + _productionLocations[productId].GetConsumerSummary();
                 if (_productionLocations[productId].ConsumerPlanetCount() > PluginConfig.productionPlanetCount.Value)
@@ -753,7 +748,7 @@ namespace Bottleneck
             rectTxt.anchoredPosition = new Vector2(20, 0);
             objsToDestroy.Add(rectTxt.gameObject);
             Text text = rectTxt.gameObject.AddComponent<Text>();
-            text.text = "clearFilterLabel".Translate(PluginConfig.GetLanguage());
+            text.text = "clearFilterLabel".Translate();
             text.fontStyle = FontStyle.Normal;
             text.fontSize = 12;
             text.verticalOverflow = VerticalWrapMode.Overflow;

--- a/BottleneckPlugin.cs
+++ b/BottleneckPlugin.cs
@@ -6,7 +6,6 @@ using Bottleneck.Nebula;
 using Bottleneck.Stats;
 using Bottleneck.UI;
 using Bottleneck.Util;
-
 using HarmonyLib;
 using UnityEngine;
 using UnityEngine.UI;
@@ -53,7 +52,7 @@ namespace Bottleneck
             _instance = this;
             _harmony = new Harmony(PluginInfo.PLUGIN_GUID);
             _harmony.PatchAll(typeof(BottleneckPlugin));
-            Logger.LogDebug(Config);
+            _harmony.PatchAll(typeof(Strings));
             PluginConfig.InitConfig(Config);
             Log.Info($"Plugin {PluginInfo.PLUGIN_GUID} {PluginInfo.PLUGIN_VERSION} is loaded!");
 
@@ -265,9 +264,9 @@ namespace Bottleneck
             if (!__instance.isDysonTab && __instance.gameData.localPlanet != null && instanceAstroBox.Items.Count > 2)
             {
                 int starId = __instance.gameData.localStar.id;
-                if (instanceAstroBox.Items[2] != "localSystemLabel".Translate())
+                if (instanceAstroBox.Items[2] != Strings.LocalSystemLabel)
                 {
-                    instanceAstroBox.Items.Insert(2, "localSystemLabel".Translate());
+                    instanceAstroBox.Items.Insert(2, Strings.LocalSystemLabel);
                     instanceAstroBox.ItemsData.Insert(2, starId * 100);
                 }
             }
@@ -487,7 +486,7 @@ namespace Bottleneck
 
         public void GetPrecursorButtonTip(int productId, out string tipTitle, out string tipText)
         {
-            tipTitle = "prodDetailsLabel".Translate();
+            tipTitle = Strings.ProdDetailsLabel;
             tipText = "";
 
             if (NebulaCompat.IsClient)
@@ -498,13 +497,13 @@ namespace Bottleneck
             }
 
             if (ItemUtil.HasPrecursors(productId))
-                tipTitle += "clickPrecursorText".Translate();
+                tipTitle += Strings.ClickPrecursorText;
             if (_productionLocations.ContainsKey(productId))
             {
                 if (_enableMadeOn)
                 {
-                    var parensMessage = ItemUtil.HasPrecursors(productId) ? "controlClickLacking".Translate() : "";
-                    var producedOnText = "producedOnLabel".Translate();
+                    var parensMessage = ItemUtil.HasPrecursors(productId) ? Strings.ControlClickLacking : "";
+                    var producedOnText = Strings.ProducedOnLabel;
                     tipText = $"{parensMessage}<b>{producedOnText}</b>\r\n" + _productionLocations[productId].GetProducerSummary();
                     if (_productionLocations[productId].PlanetCount() > PluginConfig.productionPlanetCount.Value)
                         tipTitle += $" (top {PluginConfig.productionPlanetCount.Value} / {_productionLocations[productId].PlanetCount()} planets)";
@@ -522,7 +521,7 @@ namespace Bottleneck
 
         public void GetSuccessorButtonTip(int productId, out string tipTitle, out string tipText)
         {
-            tipTitle = "conDetailsLabel".Translate();
+            tipTitle = Strings.ConDetailsLabel;
             tipText = "";
 
             if (NebulaCompat.IsClient)
@@ -533,10 +532,10 @@ namespace Bottleneck
             }
 
             if (ItemUtil.HasConsumers(productId))
-                tipTitle += "clickConsumingText".Translate();
+                tipTitle += Strings.ClickConsumingText;
             if (_productionLocations.ContainsKey(productId) && _enableMadeOn)
             { 
-                var consumedOnText = "consumedOnLabel".Translate();
+                var consumedOnText = Strings.ConsumedOnLabel;
 
                 tipText = $"<b>{consumedOnText}</b>\r\n" + _productionLocations[productId].GetConsumerSummary();
                 if (_productionLocations[productId].ConsumerPlanetCount() > PluginConfig.productionPlanetCount.Value)
@@ -748,7 +747,7 @@ namespace Bottleneck
             rectTxt.anchoredPosition = new Vector2(20, 0);
             objsToDestroy.Add(rectTxt.gameObject);
             Text text = rectTxt.gameObject.AddComponent<Text>();
-            text.text = "clearFilterLabel".Translate();
+            text.text = Strings.ClearFilterLabel;
             text.fontStyle = FontStyle.Normal;
             text.fontSize = 12;
             text.verticalOverflow = VerticalWrapMode.Overflow;

--- a/PlanetaryProductionSummary.cs
+++ b/PlanetaryProductionSummary.cs
@@ -140,7 +140,7 @@ namespace Bottleneck
                 return _prodSummary;
             }
 
-            var producersLabel = "producersLabel".Translate(PluginConfig.GetLanguage()).ToLowerInvariant();
+            var producersLabel = "producersLabel".Translate().ToLowerInvariant();
             var includedElements = _productions.GetRange(0, Math.Min(PluginConfig.productionPlanetCount.Value, _productions.Count))
                 .Select(prod => $"{prod.PlanetName}: {producersLabel}={prod.Producers}");
             _prodSummary = string.Join("\n", includedElements);
@@ -154,7 +154,7 @@ namespace Bottleneck
             {
                 return _consumerSummary;
             }
-            var consLabel = "consumersLabel".Translate(PluginConfig.GetLanguage()).ToLowerInvariant();
+            var consLabel = "consumersLabel".Translate().ToLowerInvariant();
             var includedElements = _consumers.GetRange(0, Math.Min(PluginConfig.productionPlanetCount.Value, _consumers.Count))
                 .Select(cons => $"{cons.PlanetName}: {consLabel}={cons.Consumers}");
             _consumerSummary = string.Join("\n", includedElements);

--- a/PlanetaryProductionSummary.cs
+++ b/PlanetaryProductionSummary.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Bottleneck.UI;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -140,7 +141,7 @@ namespace Bottleneck
                 return _prodSummary;
             }
 
-            var producersLabel = "producersLabel".Translate().ToLowerInvariant();
+            var producersLabel = Strings.ProducersLabel;
             var includedElements = _productions.GetRange(0, Math.Min(PluginConfig.productionPlanetCount.Value, _productions.Count))
                 .Select(prod => $"{prod.PlanetName}: {producersLabel}={prod.Producers}");
             _prodSummary = string.Join("\n", includedElements);
@@ -154,7 +155,7 @@ namespace Bottleneck
             {
                 return _consumerSummary;
             }
-            var consLabel = "consumersLabel".Translate().ToLowerInvariant();
+            var consLabel = Strings.ConsumersLabel;
             var includedElements = _consumers.GetRange(0, Math.Min(PluginConfig.productionPlanetCount.Value, _consumers.Count))
                 .Select(cons => $"{cons.PlanetName}: {consLabel}={cons.Consumers}");
             _consumerSummary = string.Join("\n", includedElements);

--- a/PluginConfig.cs
+++ b/PluginConfig.cs
@@ -18,7 +18,6 @@ namespace Bottleneck
         public static ConfigEntry<bool> systemFilter;
         public static ConfigEntry<bool> includeSecondLevelConsumerProducer;
         public static ConfigEntry<bool> disableItemHoverTip;
-        private static ConfigEntry<string> testOverrideLanguage;
 
 
         public static void InitConfig(ConfigFile confFile)
@@ -49,28 +48,6 @@ namespace Bottleneck
                 "Tells mod to ignore unlocked tech for stacking items on belts. By default uses same 'Tech Limit' value as stations use");
             statsOnly = confFile.Bind("Stats", "Disable Bottleneck", false,
                 "Disable Bottleneck functionality, use only BetterStats features");
-            var languages = Enum.GetNames(typeof(Language)).ToList().FindAll(l => l.ToString().Length == 4);
-            languages.Add("");
-            testOverrideLanguage = confFile.Bind("Internal", "TEST override language", "",
-                new ConfigDescription("Force an alt language to be used (for some text)",
-                    new AcceptableValueList<string>(
-                        languages.ToArray()
-                    )));
-            // force this setting to empty so that it has to be set at runtime and can't be left on by accident
-            testOverrideLanguage.Value = "";
-        }
-
-        public static Language GetLanguage()
-        {
-            if (testOverrideLanguage.Value.Length > 0)
-            {
-                if (Enum.TryParse(testOverrideLanguage.Value, true, out Language newLang))
-                {
-                    return newLang;
-                }
-
-            } 
-            return Localization.language;
         }
     }
 }

--- a/ProductionDeficit.cs
+++ b/ProductionDeficit.cs
@@ -157,7 +157,7 @@ namespace Bottleneck
                     for (int i = 0; i < value.neededCount; i++)
                     {
                         var requiredItem = LDB.items.Select(assemblerComponent.requires[i]);
-                        value.inputItemNames[i] = requiredItem.Name.Translate(PluginConfig.GetLanguage());
+                        value.inputItemNames[i] = requiredItem.Name.Translate();
                         value.inputItemId[i] = requiredItem.ID;
                         value.inputItemIndex[assemblerComponent.requires[i]] = i;
                     }
@@ -183,12 +183,12 @@ namespace Bottleneck
                 value = new ProductionDeficitItem
                 {
                     neededCount = assemblerComponent.requires.Length,
-                    recipeName = LDB.recipes.Select(recipeId).Name.Translate(PluginConfig.GetLanguage())
+                    recipeName = LDB.recipes.Select(recipeId).Name.Translate()
                 };
                 for (int i = 0; i < value.neededCount; i++)
                 {
                     var requiredItem = LDB.items.Select(assemblerComponent.requires[i]);
-                    value.inputItemNames[i] = requiredItem.Name.Translate(PluginConfig.GetLanguage());
+                    value.inputItemNames[i] = requiredItem.Name.Translate();
                     value.inputItemId[i] = requiredItem.ID;
                     value.inputItemIndex[assemblerComponent.requires[i]] = i;
                 }

--- a/Stats/BetterStats.cs
+++ b/Stats/BetterStats.cs
@@ -199,33 +199,6 @@ namespace Bottleneck.Stats
             return value.ToString();
         }
 
-        private static float ReverseFormat(string value)
-        {
-            string[] parts = value.Split(' ');
-            float multiplier;
-            string numericValue;
-
-            if (parts.Length > 1)
-            {
-                multiplier = parts[1] == "k" ? 1000 : (parts[1] == "M" ? 1000000 : (parts[1] == "G" ? 1000000000 : 1));
-                numericValue = parts[0];
-            }
-            else
-            {
-                multiplier = 1;
-                numericValue = parts[0].Replace(",", ".");
-            }
-
-            try
-            {
-                return float.Parse(numericValue, CultureInfo.InvariantCulture) * multiplier;
-            }
-            catch (FormatException ex)
-            {
-                throw new ArgumentException("Invalid format String : '" + value + "' (parsed as " + numericValue + " * " + multiplier + ")", nameof(value), ex);
-            }
-        }
-
         private static EnhancedUIProductEntryElements EnhanceUIProductEntry(UIProductEntry __instance)
         {
             var parent = __instance.itemIcon.transform.parent;
@@ -548,9 +521,9 @@ namespace Bottleneck.Stats
             string originalProductText = __instance.productText.text.Trim();
             string originalConsumeText = __instance.consumeText.text.Trim();
 
-
-            float originalProductValue = ReverseFormat(originalProductText);
-            float originalConsumeValue = ReverseFormat(originalConsumeText);
+            float lvDivisor = isTotalTimeWindow ? 1f : (float)__instance.lvDivisors[__instance.productionStatWindow.timeLevel];
+            float originalProductValue = __instance.entryData.production / lvDivisor;
+            float originalConsumeValue = __instance.entryData.consumption / lvDivisor;
 
             string producers = "0";
             string consumers = "0";

--- a/Stats/BetterStats.cs
+++ b/Stats/BetterStats.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using BepInEx.Logging;
 using Bottleneck.Nebula;
+using Bottleneck.UI;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.UI;
@@ -270,29 +271,29 @@ namespace Bottleneck.Stats
             __instance.consumeUnitLabel.GetComponent<RectTransform>().anchoredPosition = new Vector2(initialXOffset + valuesWidth + 4, -4);
 
             var maxProductionLabel = CopyText(__instance.productLabel, new Vector2(maxOffset, 0));
-            maxProductionLabel.text = "theoreticalMaxLabel".Translate(); 
+            maxProductionLabel.text = Strings.TheoreticalMaxLabel; 
             var maxProductionValue = CopyText(__instance.productText, new Vector2(maxOffset, 0));
             maxProductionValue.text = "0";
             var maxProductionUnit = CopyText(__instance.productUnitLabel, new Vector2(maxOffset, 0));
-            maxProductionUnit.text = "perMinLabel".Translate();
+            maxProductionUnit.text = Strings.PerMinLabel;
 
             var maxConsumptionLabel = CopyText(__instance.consumeLabel, new Vector2(maxOffset, 0));
-            maxConsumptionLabel.text = "theoreticalMaxLabel".Translate();
+            maxConsumptionLabel.text = Strings.TheoreticalMaxLabel;
             var maxConsumptionValue = CopyText(__instance.consumeText, new Vector2(maxOffset, 0));
             maxConsumptionValue.text = "0";
             var maxConsumptionUnit = CopyText(__instance.consumeUnitLabel, new Vector2(maxOffset, 0));
-            maxConsumptionUnit.text = "perMinLabel";
+            maxConsumptionUnit.text = Strings.PerMinLabel;
 
             var counterProductionLabel = CopyText(__instance.productLabel, new Vector2(-initialXOffset, 0));
             counterProductionLabel.GetComponent<RectTransform>().sizeDelta = new Vector2(60, 40);
-            counterProductionLabel.text = "producersLabel".Translate();
+            counterProductionLabel.text = Strings.ProducersLabel;
             var counterProductionValue = CopyText(__instance.productText, new Vector2(-initialXOffset, 0));
             counterProductionValue.GetComponent<RectTransform>().sizeDelta = new Vector2(60, 40);
             counterProductionValue.text = "0";
 
             var counterConsumptionLabel = CopyText(__instance.consumeLabel, new Vector2(-initialXOffset, 0));
             counterConsumptionLabel.GetComponent<RectTransform>().sizeDelta = new Vector2(60, 40);
-            counterConsumptionLabel.text = "consumersLabel".Translate();
+            counterConsumptionLabel.text = Strings.ConsumersLabel;
             var counterConsumptionValue = CopyText(__instance.consumeText, new Vector2(-initialXOffset, 0));
             counterConsumptionValue.GetComponent<RectTransform>().sizeDelta = new Vector2(60, 40);
             counterConsumptionValue.text = "0";
@@ -392,7 +393,7 @@ namespace Bottleneck.Stats
             rectTxt.anchoredPosition = new Vector2(20, 0);
 
             Text text = rectTxt.gameObject.AddComponent<Text>();
-            text.text = "dispPerSecLabel".Translate();
+            text.text = Strings.DispPerSecLabel;
             text.fontStyle = FontStyle.Normal;
             text.fontSize = 14;
             text.verticalOverflow = VerticalWrapMode.Overflow;
@@ -441,7 +442,7 @@ namespace Bottleneck.Stats
             _placeholder.alignment = TextAnchor.MiddleLeft;
             _placeholder.supportRichText = false;
             _placeholder.horizontalOverflow = HorizontalWrapMode.Overflow;
-            _placeholder.text = "filterLabel".Translate();
+            _placeholder.text = Strings.FilterLabel;
             (_placeholder.transform as RectTransform).sizeDelta = new Vector2(90, 30);
             (_placeholder.transform as RectTransform).anchoredPosition = new Vector2(5, 0);
 
@@ -529,8 +530,8 @@ namespace Bottleneck.Stats
             string consumers = "0";
             string maxProduction = "0";
             string maxConsumption = "0";
-            string unitRate = PluginConfig.displayPerSecond.Value ? "perSecLabel".Translate() : "perMinLabel".Translate();
-            string unit = isTotalTimeWindow ? "" : "perMinLabel".Translate();
+            string unitRate = PluginConfig.displayPerSecond.Value ? Strings.PerSecLabel : Strings.PerMinLabel;
+            string unit = isTotalTimeWindow ? "" : Strings.PerMinLabel;
             int divider = 1;
             bool alertOnLackOfProduction = false;
             bool warnOnHighMaxConsumption = false;
@@ -539,7 +540,7 @@ namespace Bottleneck.Stats
             if (PluginConfig.displayPerSecond.Value)
             {
                 divider = 60;
-                unit = !isTotalTimeWindow ? "perSecLabel".Translate() : unit;
+                unit = !isTotalTimeWindow ? Strings.PerSecLabel : unit;
 
                 if (!isTotalTimeWindow)
                 {

--- a/Stats/BetterStats.cs
+++ b/Stats/BetterStats.cs
@@ -270,14 +270,14 @@ namespace Bottleneck.Stats
             __instance.consumeUnitLabel.GetComponent<RectTransform>().anchoredPosition = new Vector2(initialXOffset + valuesWidth + 4, -4);
 
             var maxProductionLabel = CopyText(__instance.productLabel, new Vector2(maxOffset, 0));
-            maxProductionLabel.text = "theoreticalMaxLabel".Translate(PluginConfig.GetLanguage()); 
+            maxProductionLabel.text = "theoreticalMaxLabel".Translate(); 
             var maxProductionValue = CopyText(__instance.productText, new Vector2(maxOffset, 0));
             maxProductionValue.text = "0";
             var maxProductionUnit = CopyText(__instance.productUnitLabel, new Vector2(maxOffset, 0));
-            maxProductionUnit.text = "perMinLabel".Translate(PluginConfig.GetLanguage());
+            maxProductionUnit.text = "perMinLabel".Translate();
 
             var maxConsumptionLabel = CopyText(__instance.consumeLabel, new Vector2(maxOffset, 0));
-            maxConsumptionLabel.text = "theoreticalMaxLabel".Translate(PluginConfig.GetLanguage());
+            maxConsumptionLabel.text = "theoreticalMaxLabel".Translate();
             var maxConsumptionValue = CopyText(__instance.consumeText, new Vector2(maxOffset, 0));
             maxConsumptionValue.text = "0";
             var maxConsumptionUnit = CopyText(__instance.consumeUnitLabel, new Vector2(maxOffset, 0));
@@ -285,14 +285,14 @@ namespace Bottleneck.Stats
 
             var counterProductionLabel = CopyText(__instance.productLabel, new Vector2(-initialXOffset, 0));
             counterProductionLabel.GetComponent<RectTransform>().sizeDelta = new Vector2(60, 40);
-            counterProductionLabel.text = "producersLabel".Translate(PluginConfig.GetLanguage());
+            counterProductionLabel.text = "producersLabel".Translate();
             var counterProductionValue = CopyText(__instance.productText, new Vector2(-initialXOffset, 0));
             counterProductionValue.GetComponent<RectTransform>().sizeDelta = new Vector2(60, 40);
             counterProductionValue.text = "0";
 
             var counterConsumptionLabel = CopyText(__instance.consumeLabel, new Vector2(-initialXOffset, 0));
             counterConsumptionLabel.GetComponent<RectTransform>().sizeDelta = new Vector2(60, 40);
-            counterConsumptionLabel.text = "consumersLabel".Translate(PluginConfig.GetLanguage());
+            counterConsumptionLabel.text = "consumersLabel".Translate();
             var counterConsumptionValue = CopyText(__instance.consumeText, new Vector2(-initialXOffset, 0));
             counterConsumptionValue.GetComponent<RectTransform>().sizeDelta = new Vector2(60, 40);
             counterConsumptionValue.text = "0";
@@ -392,7 +392,7 @@ namespace Bottleneck.Stats
             rectTxt.anchoredPosition = new Vector2(20, 0);
 
             Text text = rectTxt.gameObject.AddComponent<Text>();
-            text.text = "dispPerSecLabel".Translate(PluginConfig.GetLanguage());
+            text.text = "dispPerSecLabel".Translate();
             text.fontStyle = FontStyle.Normal;
             text.fontSize = 14;
             text.verticalOverflow = VerticalWrapMode.Overflow;
@@ -441,7 +441,7 @@ namespace Bottleneck.Stats
             _placeholder.alignment = TextAnchor.MiddleLeft;
             _placeholder.supportRichText = false;
             _placeholder.horizontalOverflow = HorizontalWrapMode.Overflow;
-            _placeholder.text = "filterLabel".Translate(PluginConfig.GetLanguage());
+            _placeholder.text = "filterLabel".Translate();
             (_placeholder.transform as RectTransform).sizeDelta = new Vector2(90, 30);
             (_placeholder.transform as RectTransform).anchoredPosition = new Vector2(5, 0);
 
@@ -529,8 +529,8 @@ namespace Bottleneck.Stats
             string consumers = "0";
             string maxProduction = "0";
             string maxConsumption = "0";
-            string unitRate = PluginConfig.displayPerSecond.Value ? "perSecLabel".Translate(PluginConfig.GetLanguage()) : "perMinLabel".Translate(PluginConfig.GetLanguage());
-            string unit = isTotalTimeWindow ? "" : "perMinLabel".Translate(PluginConfig.GetLanguage());
+            string unitRate = PluginConfig.displayPerSecond.Value ? "perSecLabel".Translate() : "perMinLabel".Translate();
+            string unit = isTotalTimeWindow ? "" : "perMinLabel".Translate();
             int divider = 1;
             bool alertOnLackOfProduction = false;
             bool warnOnHighMaxConsumption = false;
@@ -539,7 +539,7 @@ namespace Bottleneck.Stats
             if (PluginConfig.displayPerSecond.Value)
             {
                 divider = 60;
-                unit = !isTotalTimeWindow ? "perSecLabel".Translate(PluginConfig.GetLanguage()) : unit;
+                unit = !isTotalTimeWindow ? "perSecLabel".Translate() : unit;
 
                 if (!isTotalTimeWindow)
                 {

--- a/UI/BottleneckProductEntryElement.cs
+++ b/UI/BottleneckProductEntryElement.cs
@@ -43,7 +43,7 @@ namespace Bottleneck.UI
 
         private static string GetItemName(int itemId)
         {
-            return LDB.items.Select(itemId).Name.Translate(PluginConfig.GetLanguage());
+            return LDB.items.Select(itemId).Name.Translate();
         }
     }
 }

--- a/UI/Strings.cs
+++ b/UI/Strings.cs
@@ -1,73 +1,126 @@
-using CommonAPI.Systems;
+using Bottleneck.Util;
+using HarmonyLib;
 
 namespace Bottleneck.UI
 {
     public static class Strings
     {
-        public static void Init()
+        private static bool isZHCN = false;
+
+        [HarmonyPostfix]
+        [HarmonyPatch(typeof(GameOption), "Apply")]
+        public static void ApplyLanguageChange()
         {
-            ProtoRegistry.RegisterString("clearFilterLabel", "Clear filter", "清除筛选器");
-            ProtoRegistry.RegisterString("localSystemLabel", "Local System", "本地系统");
-
-            // The Chinese display here is /min, so there is no need to translate here, /sec too.
-            ProtoRegistry.RegisterString("perMinLabel", "/min", "/min");
-            ProtoRegistry.RegisterString("perSecLabel", "/sec", "/sec");
-
-            ProtoRegistry.RegisterString("dispPerSecLabel", "Display /sec", "以 /秒 显示");
-            ProtoRegistry.RegisterString("filterLabel", "Filter", "筛选");
-            
-            ProtoRegistry.RegisterString("consumersLabel", "Consumers", "消耗设施");
-            ProtoRegistry.RegisterString("producersLabel", "Producers", "生产设施");
-            ProtoRegistry.RegisterString("theoreticalMaxLabel", "Theoretical max", "理论最大值", "Maximum théorique");
-
-            ProtoRegistry.RegisterString("prodDetailsLabel", "Production Details", "生产详情", "Détails de fabrication");
-            ProtoRegistry.RegisterString("clickPrecursorText", " (click to show only precursor items)", "（鼠标单击 仅展示所有前置材料）");
-            ProtoRegistry.RegisterString("controlClickLacking", "(Control click see only precursors that are lacking)\r\n", "（按住Ctrl+鼠标单击 仅展示产量不足的前置材料）\r\n");
-            ProtoRegistry.RegisterString("producedOnLabel", "Produced on", "生产于");
-
-            ProtoRegistry.RegisterString("conDetailsLabel", "Consumption Details", "消耗详情", "Détails de la consommation");
-            ProtoRegistry.RegisterString("clickConsumingText", " (click to show only consuming items)", "（鼠标单击 仅展示用于制作的物品）");
-            ProtoRegistry.RegisterString("consumedOnLabel", "Consumed on", "消耗于");
-
-            // text used in bottleneck message for an item
-            ProtoRegistry.RegisterString("needLabel", "Need", "需要");
-            ProtoRegistry.RegisterString("currentLabel", "current", "当前");
-            ProtoRegistry.RegisterString("stackingLabel", "Stacking", "产物堆积");
-            ProtoRegistry.RegisterString("underPoweredLabel", "Under Powered", "电力不足");
-            ProtoRegistry.RegisterString("missingSprayLabel", "Missing spray", "缺少增产剂");
-            ProtoRegistry.RegisterString("bottlenecksLabel", "Bottlenecks", "瓶颈");
-            // text used in proliferator selection
-            ProtoRegistry.RegisterString("proliferatorCalcDisabledLabel", "Proliferator Calculation Disabled", "增产剂计算已禁用");
-            ProtoRegistry.RegisterString("proliferatorCalcDisabledHover", "Don't use Proliferator Points for calculation of Theoretical max values", "不使用增产点数计算理论最大值");
-            ProtoRegistry.RegisterString("proliferatorCalcEnabledLabel", "Proliferator Calculation Enabled", "增产剂计算已启用");
-
-            ProtoRegistry.RegisterString("assemblerSelection", "Assembler Selection Mode", "生产设施当前选择 模式");
-            ProtoRegistry.RegisterString("assemblerSelectionHover", "Max values calculated using currently selected mode for each assembler.", "使用每个生产设施 当前选择 的模式计算理论最大值");
-
-            ProtoRegistry.RegisterString("forceProductivity", "Force Productivity Mode", "强制 额外产出 模式");
-            ProtoRegistry.RegisterString("forceProductivityHover", "Max values calculated as if all all assemblers were set to 'Extra Products'.", "假设每个生产设施使用 额外产出 模式计算理论最大值");
-
-            ProtoRegistry.RegisterString("forceSpeed", "Force Speed Mode", "强制 生产加速 模式");
-            ProtoRegistry.RegisterString("forceSpeedHover", "Max values calculated as if all all assemblers were set to 'Production Speedup'.", "假设每个生产设施使用 生产加速 模式计算理论最大值");
-
-            ProtoRegistry.RegisterString("recipePreText", "Recipe", "配方");
+            LoadStrings();
         }
 
-        public static string NeedLabel => "needLabel".Translate();
-        public static string CurrentLabel => "currentLabel".Translate();
-        public static string StackingLabel => "stackingLabel".Translate();
-        public static string UnderPoweredLabel => "underPoweredLabel".Translate();
-        public static string MissingSprayLabel => "missingSprayLabel".Translate();
-        public static string BottlenecksLabel => "bottlenecksLabel".Translate();
-        public static string ProliferatorCalculationDisabled => "proliferatorCalcDisabledLabel".Translate();
-        public static string ProliferatorCalculationDisabledHover => "proliferatorCalcDisabledHover".Translate();
-        public static string ProliferatorCalculationEnabled => "proliferatorCalcEnabledLabel".Translate();
-        public static string AssemblerSelectionMode => "assemblerSelection".Translate();
-        public static string AssemblerSelectionHover => "assemblerSelectionHover".Translate();
-        public static string ForceProductivityMode => "forceProductivity".Translate();
-        public static string ForceProductivityHover => "forceProductivityHover".Translate();
-        public static string ForceSpeedMode => "forceSpeed".Translate();
-        public static string ForceSpeedModeHover => "forceSpeedHover".Translate();
-        public static string RecipePreText => "recipePreText".Translate();
+        public static void LoadStrings()
+        {
+            isZHCN = false;
+            try
+            {
+                isZHCN = IsZHCN();
+            }
+            catch (System.Exception e)
+            {
+                Log.Warn("Get Localization.isZHCN error!" + e);
+            }
+
+            RegisterString(ref ClearFilterLabel, "Clear filter", "清除筛选器");
+            RegisterString(ref LocalSystemLabel, "Local System", "本地系统");
+
+            // The Chinese display here is /min, so there is no need to translate here, /sec too.
+            RegisterString(ref PerMinLabel, "/min", "/min");
+            RegisterString(ref PerSecLabel, "/sec", "/sec");
+
+            RegisterString(ref DispPerSecLabel, "Display /sec", "以 /秒 显示");
+            RegisterString(ref FilterLabel, "Filter", "筛选");
+            
+            RegisterString(ref ConsumersLabel, "Consumers", "消耗设施");
+            RegisterString(ref ProducersLabel, "Producers", "生产设施");
+            RegisterString(ref TheoreticalMaxLabel, "Theoretical max", "理论最大值");
+
+            RegisterString(ref ProdDetailsLabel, "Production Details", "生产详情");
+            RegisterString(ref ClickPrecursorText, " (click to show only precursor items)", "（鼠标单击 仅展示所有前置材料）");
+            RegisterString(ref ControlClickLacking, "(Control click see only precursors that are lacking)\r\n", "（按住Ctrl+鼠标单击 仅展示产量不足的前置材料）\r\n");
+            RegisterString(ref ProducedOnLabel, "Produced on", "生产于");
+
+            RegisterString(ref ConDetailsLabel, "Consumption Details", "消耗详情");
+            RegisterString(ref ClickConsumingText, " (click to show only consuming items)", "（鼠标单击 仅展示用于制作的物品）");
+            RegisterString(ref ConsumedOnLabel, "Consumed on", "消耗于");
+
+            // text used in bottleneck message for an item
+            RegisterString(ref NeedLabel, "Need", "需要");
+            RegisterString(ref CurrentLabel, "current", "当前");
+            RegisterString(ref StackingLabel, "Stacking", "产物堆积");
+            RegisterString(ref UnderPoweredLabel, "Under Powered", "电力不足");
+            RegisterString(ref MissingSprayLabel, "Missing spray", "缺少增产剂");
+            RegisterString(ref BottlenecksLabel, "Bottlenecks", "瓶颈");
+            // text used in proliferator selection
+            RegisterString(ref ProliferatorCalculationDisabled, "Proliferator Calculation Disabled", "增产剂计算已禁用");
+            RegisterString(ref ProliferatorCalculationDisabledHover, "Don't use Proliferator Points for calculation of Theoretical max values", "不使用增产点数计算理论最大值");
+            RegisterString(ref ProliferatorCalculationEnabled, "Proliferator Calculation Enabled", "增产剂计算已启用");
+
+            RegisterString(ref AssemblerSelectionMode, "Assembler Selection Mode", "生产设施当前选择 模式");
+            RegisterString(ref AssemblerSelectionHover, "Max values calculated using currently selected mode for each assembler.", "使用每个生产设施 当前选择 的模式计算理论最大值");
+
+            RegisterString(ref ForceProductivityMode, "Force Productivity Mode", "强制 额外产出 模式");
+            RegisterString(ref ForceProductivityHover, "Max values calculated as if all all assemblers were set to 'Extra Products'.", "假设每个生产设施使用 额外产出 模式计算理论最大值");
+
+            RegisterString(ref ForceSpeedMode, "Force Speed Mode", "强制 生产加速 模式");
+            RegisterString(ref ForceSpeedModeHover, "Max values calculated as if all all assemblers were set to 'Production Speedup'.", "假设每个生产设施使用 生产加速 模式计算理论最大值");
+            RegisterString(ref RecipePreText, "Recipe", "配方");
+        }
+
+        private static bool IsZHCN()
+        {
+            return Localization.isZHCN; // Separate so it won't break the whole part
+        }
+
+        private static void RegisterString(ref string result, string enTrans, string cnTrans)
+        {
+            string key = nameof(result);
+            string translate = key.Translate();
+            if (!string.Equals(key, translate))
+            {   // if there is translation
+                result = translate;
+                return;
+            }
+            result = isZHCN ? cnTrans : enTrans;
+        }
+
+        public static string ClearFilterLabel;
+        public static string LocalSystemLabel;
+        public static string PerMinLabel;
+        public static string PerSecLabel;
+        public static string DispPerSecLabel;
+        public static string FilterLabel;
+        public static string ConsumersLabel;
+        public static string ProducersLabel;
+        public static string TheoreticalMaxLabel;
+        public static string ProdDetailsLabel;
+        public static string ClickPrecursorText;
+        public static string ControlClickLacking;
+        public static string ProducedOnLabel;
+        public static string ConDetailsLabel;
+        public static string ClickConsumingText;
+        public static string ConsumedOnLabel;
+
+        public static string NeedLabel;
+        public static string CurrentLabel;
+        public static string StackingLabel;
+        public static string UnderPoweredLabel;
+        public static string MissingSprayLabel;
+        public static string BottlenecksLabel;
+        public static string ProliferatorCalculationDisabled;
+        public static string ProliferatorCalculationDisabledHover;
+        public static string ProliferatorCalculationEnabled;
+        public static string AssemblerSelectionMode;
+        public static string AssemblerSelectionHover;
+        public static string ForceProductivityMode;
+        public static string ForceProductivityHover;
+        public static string ForceSpeedMode;
+        public static string ForceSpeedModeHover;
+        public static string RecipePreText;
     }
 }

--- a/UI/Strings.cs
+++ b/UI/Strings.cs
@@ -53,21 +53,21 @@ namespace Bottleneck.UI
             ProtoRegistry.RegisterString("recipePreText", "Recipe", "配方");
         }
 
-        public static string NeedLabel => "needLabel".Translate(PluginConfig.GetLanguage());
-        public static string CurrentLabel => "currentLabel".Translate(PluginConfig.GetLanguage());
-        public static string StackingLabel => "stackingLabel".Translate(PluginConfig.GetLanguage());
-        public static string UnderPoweredLabel => "underPoweredLabel".Translate(PluginConfig.GetLanguage());
-        public static string MissingSprayLabel => "missingSprayLabel".Translate(PluginConfig.GetLanguage());
-        public static string BottlenecksLabel => "bottlenecksLabel".Translate(PluginConfig.GetLanguage());
-        public static string ProliferatorCalculationDisabled => "proliferatorCalcDisabledLabel".Translate(PluginConfig.GetLanguage());
-        public static string ProliferatorCalculationDisabledHover => "proliferatorCalcDisabledHover".Translate(PluginConfig.GetLanguage());
-        public static string ProliferatorCalculationEnabled => "proliferatorCalcEnabledLabel".Translate(PluginConfig.GetLanguage());
-        public static string AssemblerSelectionMode => "assemblerSelection".Translate(PluginConfig.GetLanguage());
-        public static string AssemblerSelectionHover => "assemblerSelectionHover".Translate(PluginConfig.GetLanguage());
-        public static string ForceProductivityMode => "forceProductivity".Translate(PluginConfig.GetLanguage());
-        public static string ForceProductivityHover => "forceProductivityHover".Translate(PluginConfig.GetLanguage());
-        public static string ForceSpeedMode => "forceSpeed".Translate(PluginConfig.GetLanguage());
-        public static string ForceSpeedModeHover => "forceSpeedHover".Translate(PluginConfig.GetLanguage());
-        public static string RecipePreText => "recipePreText".Translate(PluginConfig.GetLanguage());
+        public static string NeedLabel => "needLabel".Translate();
+        public static string CurrentLabel => "currentLabel".Translate();
+        public static string StackingLabel => "stackingLabel".Translate();
+        public static string UnderPoweredLabel => "underPoweredLabel".Translate();
+        public static string MissingSprayLabel => "missingSprayLabel".Translate();
+        public static string BottlenecksLabel => "bottlenecksLabel".Translate();
+        public static string ProliferatorCalculationDisabled => "proliferatorCalcDisabledLabel".Translate();
+        public static string ProliferatorCalculationDisabledHover => "proliferatorCalcDisabledHover".Translate();
+        public static string ProliferatorCalculationEnabled => "proliferatorCalcEnabledLabel".Translate();
+        public static string AssemblerSelectionMode => "assemblerSelection".Translate();
+        public static string AssemblerSelectionHover => "assemblerSelectionHover".Translate();
+        public static string ForceProductivityMode => "forceProductivity".Translate();
+        public static string ForceProductivityHover => "forceProductivityHover".Translate();
+        public static string ForceSpeedMode => "forceSpeed".Translate();
+        public static string ForceSpeedModeHover => "forceSpeedHover".Translate();
+        public static string RecipePreText => "recipePreText".Translate();
     }
 }

--- a/Util/ItemUtil.cs
+++ b/Util/ItemUtil.cs
@@ -87,7 +87,7 @@ namespace Bottleneck.Util
                 return $"UNKNOWN_RECIPE_${recipeId}";
             }
             
-            _recipeNames[recipeId] = recipeProto.Name.Translate(PluginConfig.GetLanguage());
+            _recipeNames[recipeId] = recipeProto.Name.Translate();
             return _recipeNames[recipeId];
         }
     }


### PR DESCRIPTION
In the new game version, `Localization` class is reworked so the string translate method has to change.
In this PR, the strings are stored in a static string pool `Strings` and reloaded after applying the options.
It no longer needs CommonAPI as a dependency and has built-in English and Chinese translation.

If the `string.Translate()` provides a translation to strings in the string pool, it will use the translation first.
In this way, you can add translations for other languages by other translation plugins.

Fix #16, #14